### PR TITLE
Add renewable energy forecasting pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+data/
+*.xgb

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Renewable Energy Forecasting Pipeline
+
+This project demonstrates a basic pipeline to download weather data, simulate solar and wind output, engineer features, and train an XGBoost model for forecasting.
+
+## Scripts
+
+- `scripts/collect_data.py` – Download hourly weather data from the [Open-Meteo](https://open-meteo.com/) archive API for the locations listed in `locations.json`.
+- `scripts/simulate_output.py` – Add simple physics-informed estimates of solar and wind output for each weather record.
+- `scripts/feature_engineer.py` – Create additional time-based and rolling statistics features for model training.
+- `scripts/train_model.py` – Train an XGBoost regression model to predict output seven days ahead.
+
+## Quick Example
+
+```bash
+# 1. Download weather data (requires internet access)
+python scripts/collect_data.py
+
+# 2. Simulate renewable system output
+python scripts/simulate_output.py data/raw/weather_raw_Berlin_DE_52.52_13.405.csv data/processed/berlin_simulated.csv --panel_area 2.0 --turbine_radius 1.2
+
+# 3. Feature engineering
+python scripts/feature_engineer.py data/processed/berlin_simulated.csv data/processed/berlin_features.csv
+
+# 4. Train the forecasting model
+python scripts/train_model.py data/processed/berlin_features.csv simulated_solar_output_w --model_out berlin_solar.xgb
+```
+
+The example commands above fetch data for Berlin and create a model predicting solar output. Additional locations are defined in `locations.json` and will be processed automatically when running `collect_data.py`.
+
+Note that access to the Open-Meteo API may be blocked in some environments. If so, the data download step will fail and the remaining pipeline stages cannot run until suitable data is available.

--- a/locations.json
+++ b/locations.json
@@ -1,0 +1,5 @@
+[
+  {"name": "Berlin", "country": "DE", "latitude": 52.52, "longitude": 13.405},
+  {"name": "Nairobi", "country": "KE", "latitude": -1.2921, "longitude": 36.8219},
+  {"name": "Sydney", "country": "AU", "latitude": -33.8688, "longitude": 151.2093}
+]

--- a/scripts/collect_data.py
+++ b/scripts/collect_data.py
@@ -1,0 +1,76 @@
+import json
+import os
+from datetime import datetime, timedelta
+import requests
+import pandas as pd
+
+BASE_URL = "https://archive-api.open-meteo.com/v1/archive"
+HOURLY_VARS = [
+    "temperature_2m",
+    "dew_point_2m",
+    "relative_humidity_2m",
+    "apparent_temperature",
+    "precipitation",
+    "rain",
+    "snowfall",
+    "cloud_cover",
+    "shortwave_radiation",
+    "surface_pressure",
+    "wind_speed_10m",
+    "wind_direction_10m",
+    "wind_gusts_10m",
+]
+
+
+def load_locations(path="locations.json"):
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def fetch_location(location, start_date, end_date):
+    params = {
+        "latitude": location["latitude"],
+        "longitude": location["longitude"],
+        "start_date": start_date,
+        "end_date": end_date,
+        "hourly": ",".join(HOURLY_VARS),
+        "timezone": "UTC",
+    }
+    response = requests.get(BASE_URL, params=params, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    hourly = data.get("hourly", {})
+    if not hourly:
+        return pd.DataFrame()
+    df = pd.DataFrame(hourly)
+    df.insert(0, "time", pd.to_datetime(df["time"]))
+    return df
+
+
+def save_data(df, location):
+    name = location["name"].replace(" ", "_")
+    fname = f"weather_raw_{name}_{location['country']}_{location['latitude']}_{location['longitude']}.csv"
+    path = os.path.join("data", "raw", fname)
+    df.to_csv(path, index=False)
+    return path
+
+
+def main():
+    locations = load_locations()
+    # default timeframe: last 60 days
+    end = datetime.utcnow().date()
+    start = end - timedelta(days=60)
+    for loc in locations:
+        try:
+            df = fetch_location(loc, start.isoformat(), end.isoformat())
+            if not df.empty:
+                out = save_data(df, loc)
+                print(f"Saved {out} with {len(df)} rows")
+            else:
+                print(f"No data returned for {loc['name']}")
+        except Exception as exc:
+            print(f"Failed to fetch {loc['name']}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/feature_engineer.py
+++ b/scripts/feature_engineer.py
@@ -1,0 +1,29 @@
+import argparse
+import pandas as pd
+
+
+def engineer_features(df: pd.DataFrame, lags=1, rolling=3):
+    df["hour"] = df["time"].dt.hour
+    df["day_of_year"] = df["time"].dt.dayofyear
+    if "shortwave_radiation" in df.columns:
+        df["radiation_roll_mean"] = df["shortwave_radiation"].rolling(rolling, min_periods=1).mean()
+    if "simulated_solar_output_w" in df.columns:
+        df["solar_output_lag1"] = df["simulated_solar_output_w"].shift(lags)
+    if "simulated_wind_output_w" in df.columns:
+        df["wind_output_lag1"] = df["simulated_wind_output_w"].shift(lags)
+    df.dropna(inplace=True)
+    return df
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_csv")
+    parser.add_argument("output_csv")
+    args = parser.parse_args()
+    df = pd.read_csv(args.input_csv, parse_dates=["time"])
+    df = engineer_features(df)
+    df.to_csv(args.output_csv, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/simulate_output.py
+++ b/scripts/simulate_output.py
@@ -1,0 +1,32 @@
+import argparse
+import math
+import pandas as pd
+
+SOLAR_EFFICIENCY = 0.2  # typical panel efficiency
+WIND_EFFICIENCY = 0.4   # typical turbine efficiency
+AIR_DENSITY = 1.225     # kg/m^3
+
+
+def simulate(df: pd.DataFrame, panel_area=1.0, turbine_radius=1.0):
+    if "shortwave_radiation" in df.columns:
+        df["simulated_solar_output_w"] = df["shortwave_radiation"] * panel_area * SOLAR_EFFICIENCY
+    if "wind_speed_10m" in df.columns:
+        swept_area = math.pi * turbine_radius ** 2
+        df["simulated_wind_output_w"] = 0.5 * AIR_DENSITY * swept_area * (df["wind_speed_10m"] ** 3) * WIND_EFFICIENCY
+    return df
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_csv")
+    parser.add_argument("output_csv")
+    parser.add_argument("--panel_area", type=float, default=1.0)
+    parser.add_argument("--turbine_radius", type=float, default=1.0)
+    args = parser.parse_args()
+    df = pd.read_csv(args.input_csv, parse_dates=["time"])
+    df = simulate(df, args.panel_area, args.turbine_radius)
+    df.to_csv(args.output_csv, index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -1,0 +1,50 @@
+import argparse
+import pandas as pd
+import xgboost as xgb
+from sklearn.metrics import mean_absolute_error
+from sklearn.model_selection import train_test_split
+
+HORIZON = 24 * 7  # hours ahead
+
+
+def prepare_data(df: pd.DataFrame, target_col: str):
+    df = df.copy()
+    df["target"] = df[target_col].shift(-HORIZON)
+    df.dropna(inplace=True)
+    X = df.drop(columns=[target_col, "time", "target"])
+    y = df["target"]
+    return X, y
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_csv")
+    parser.add_argument("target_col", default="simulated_solar_output_w")
+    parser.add_argument("--model_out", default="model.xgb")
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.input_csv, parse_dates=["time"])
+    X, y = prepare_data(df, args.target_col)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+
+    dtrain = xgb.DMatrix(X_train, label=y_train)
+    dtest = xgb.DMatrix(X_test, label=y_test)
+
+    params = {
+        "objective": "reg:squarederror",
+        "tree_method": "hist",
+        "max_depth": 6,
+        "eta": 0.1,
+        "subsample": 0.8,
+        "colsample_bytree": 0.8,
+    }
+    model = xgb.train(params, dtrain, num_boost_round=200)
+    preds = model.predict(dtest)
+    mae = mean_absolute_error(y_test, preds)
+    print(f"MAE: {mae:.3f}")
+    model.save_model(args.model_out)
+    print(f"Model saved to {args.model_out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add pipeline scripts for collecting data, simulating renewable output, feature engineering, and model training
- include sample locations
- document pipeline usage in README
- ignore data and model artifacts

## Testing
- `python scripts/simulate_output.py data/raw/weather_raw_Berlin_DE_52.52_13.405.csv data/processed/berlin_simulated.csv --panel_area 2 --turbine_radius 1`
- `python scripts/feature_engineer.py data/processed/berlin_simulated.csv data/processed/berlin_features.csv`
- `python scripts/train_model.py data/processed/berlin_features.csv simulated_solar_output_w --model_out berlin_solar.xgb` *(fails: ValueError due to insufficient samples)*

------
https://chatgpt.com/codex/tasks/task_e_685935612424832aa615ff4476fea4e8